### PR TITLE
Changed test query

### DIFF
--- a/jar-module/src/main/java/org/opensingular/dbuserprovider/persistence/DataSourceProvider.java
+++ b/jar-module/src/main/java/org/opensingular/dbuserprovider/persistence/DataSourceProvider.java
@@ -36,7 +36,7 @@ public class DataSourceProvider implements Closeable {
         hikariConfig.setPassword(pass);
         hikariConfig.setPoolName(StringUtils.capitalize("SINGULAR-USER-PROVIDER-" + SIMPLE_DATE_FORMAT.format(new Date())));
         hikariConfig.setJdbcUrl(url);
-        hikariConfig.setConnectionTestQuery("select 1");
+        hikariConfig.setConnectionTestQuery(rdbms.getTestString());
         hikariConfig.setDriverClassName(rdbms.getDriver());
         HikariDataSource newDS = new HikariDataSource(hikariConfig);
         newDS.validate();


### PR DESCRIPTION
Hikari was using `SELECT 1` query to test connection. This query is not valid for Oracle database (maybe for others too). In RDBM enum test query was already defined, so I used that.