### PR TITLE
Make Lombok compatible with JDK 16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
-        <lombok.version>1.18.12</lombok.version>
+        <lombok.version>1.18.22</lombok.version>
         <jboss-logging.version>3.3.1.Final</jboss-logging.version>
         <keycloak.version>8.0.1</keycloak.version>
         <auto-service.version>1.0-rc5</auto-service.version>


### PR DESCRIPTION
After changing this dependency version I was able to successfully generate the .ear file and configure integration with a MySQL database on my Keycloak installation.

References:
- https://stackoverflow.com/a/66981165/3072406
- https://github.com/projectlombok/lombok/issues/2681