### PR TITLE
bug fix to allow display of existing local users in Master -> Manage -> Users

### DIFF
--- a/jar-module/src/main/java/org/opensingular/dbuserprovider/DBUserStorageProviderFactory.java
+++ b/jar-module/src/main/java/org/opensingular/dbuserprovider/DBUserStorageProviderFactory.java
@@ -23,9 +23,9 @@ public class DBUserStorageProviderFactory implements UserStorageProviderFactory<
     private static final String PARAMETER_PLACEHOLDER_HELP = "Use '?' as parameter placeholder character (replaced only once). ";
     private static final String DEFAULT_HELP_TEXT          = "Select to query all users you must return at least: \"id\". " +
             "            \"username\"," +
-            "            \"email\" (opcional)," +
-            "            \"firstName\" (opcional)," +
-            "            \"lastName\" (opcional). Any other parameter can be mapped by aliases to a realm scope";
+            "            \"email\" (optional)," +
+            "            \"firstName\" (optional)," +
+            "            \"lastName\" (optional). Any other parameter can be mapped by aliases to a realm scope";
     private static final String PARAMETER_HELP             = " The %s is passed as query parameter.";
 
 

--- a/jar-module/src/main/java/org/opensingular/dbuserprovider/persistence/UserRepository.java
+++ b/jar-module/src/main/java/org/opensingular/dbuserprovider/persistence/UserRepository.java
@@ -138,7 +138,7 @@ public class UserRepository {
     }
 
     public List<Map<String, String>> findUsers(String query) {
-        if (query.length() < 2) {
+        if (query == null || query.length() < 2) {
             log.info("Ignoring query with less than two characters as search term");
             return Collections.emptyList();
         }


### PR DESCRIPTION
Fixes a null-pointer exception when we click Master -> Manage -> Users and there are existing Keycloak users (not gotten through User Federation).
(also fixes a minor text typo in a tooltip displayed in the Keycloak User Federation admin interface)