### PR TITLE
Inexistent username trying to login caused a server exception instead…

### DIFF
--- a/jar-module/src/main/java/org/opensingular/dbuserprovider/persistence/UserRepository.java
+++ b/jar-module/src/main/java/org/opensingular/dbuserprovider/persistence/UserRepository.java
@@ -91,8 +91,7 @@ public class UserRepository {
 
     private Integer readInt(ResultSet rs) {
         try {
-            rs.next();
-            return rs.getInt(1);
+            return rs.next() ? rs.getInt(1) : null;
         } catch (Exception e) {
             throw new DBUserStorageException(e.getMessage(), e);
         }
@@ -100,8 +99,7 @@ public class UserRepository {
 
     private Boolean readBoolean(ResultSet rs) {
         try {
-            rs.next();
-            return rs.getBoolean(1);
+            return rs.next() ? rs.getBoolean(1) : null;
         } catch (Exception e) {
             throw new DBUserStorageException(e.getMessage(), e);
         }
@@ -109,8 +107,7 @@ public class UserRepository {
 
     private String readString(ResultSet rs) {
         try {
-            rs.next();
-            return rs.getString(1);
+            return rs.next() ? rs.getString(1) : null;
         } catch (Exception e) {
             throw new DBUserStorageException(e.getMessage(), e);
         }
@@ -148,7 +145,7 @@ public class UserRepository {
     public boolean validateCredentials(String username, String password) {
         String hash = Optional.ofNullable(doQuery(queryConfigurations.getFindPasswordHash(), null, this::readString, username)).orElse("");
         if (queryConfigurations.isBlowfish()) {
-            return BCrypt.checkpw(password, hash);
+            return hash != "" && BCrypt.checkpw(password, hash);
         } else {
             MessageDigest digest   = DigestUtils.getDigest(queryConfigurations.getHashFunction());
             byte[]        pwdBytes = StringUtils.getBytesUtf8(password);


### PR DESCRIPTION
… of just refusing access.

e.g. If you try to login with username "xyz" and that this user is not found in the DB, the ResultSet of the query trying to fetch the password hash for this user will be empty (i.e. 0 rows returned) and Keycloak would show an error similar to this (with a long stack trace in the server log):
```
We are sorry...
Unexpected error when handling authentication request to identity provider.
```

This PR fixes this problem in readString (used to get the password), and the same weakness found in readInt and readBoolean.

Also, BCrypt.checkpw requires a hash that contains some characters, and we don't have any if the user is not found, so validateCredentials will just return false in that scenario (i.e. the user is not found, so the credentials are not valid).