### PR TITLE
Don't crash if a secondary attribute can't be stored, but log the error

### DIFF
--- a/src/main/java/org/opensingular/dbuserprovider/DBUserStorageProvider.java
+++ b/src/main/java/org/opensingular/dbuserprovider/DBUserStorageProvider.java
@@ -16,6 +16,7 @@ import org.keycloak.storage.StorageId;
 import org.keycloak.storage.UserStorageProvider;
 import org.keycloak.storage.user.UserLookupProvider;
 import org.keycloak.storage.user.UserQueryProvider;
+import org.keycloak.storage.user.UserRegistrationProvider;
 import org.opensingular.dbuserprovider.model.QueryConfigurations;
 import org.opensingular.dbuserprovider.model.UserAdapter;
 import org.opensingular.dbuserprovider.persistence.DataSourceProvider;
@@ -29,7 +30,7 @@ import java.util.stream.Collectors;
 
 @JBossLog
 public class DBUserStorageProvider implements UserStorageProvider,
-        UserLookupProvider, UserQueryProvider, CredentialInputUpdater, CredentialInputValidator {
+        UserLookupProvider, UserQueryProvider, CredentialInputUpdater, CredentialInputValidator, UserRegistrationProvider {
 
     private final KeycloakSession session;
     private final ComponentModel  model;
@@ -216,5 +217,21 @@ public class DBUserStorageProvider implements UserStorageProvider,
         log.infov("search for group members: realm={0} attrName={1} attrValue={2}", realm.getId(), attrName, attrValue);
 
         return Collections.emptyList();
+    }
+
+
+    @Override
+    public UserModel addUser(RealmModel realm, String username) {
+        // from documentation: "If your provider has a configuration switch to turn off adding a user, returning null from this method will skip the provider and call the next one."
+        return null;
+    }
+
+
+    @Override
+    public boolean removeUser(RealmModel realm, UserModel user) {
+
+        log.infov("unlink user: realm={0} userId={1} username={2}", realm.getId(), user.getId(), user.getUsername());
+
+        return true;
     }
 }

--- a/src/main/java/org/opensingular/dbuserprovider/model/UserAdapter.java
+++ b/src/main/java/org/opensingular/dbuserprovider/model/UserAdapter.java
@@ -1,5 +1,6 @@
 package org.opensingular.dbuserprovider.model;
 
+import lombok.extern.jbosslog.JBossLog;
 import org.apache.commons.lang3.StringUtils;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.models.KeycloakSession;
@@ -15,6 +16,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+@JBossLog
 public class UserAdapter extends AbstractUserAdapterFederatedStorage {
 
     private final String keycloakId;
@@ -24,15 +26,19 @@ public class UserAdapter extends AbstractUserAdapterFederatedStorage {
         super(session, realm, model);
         this.keycloakId = StorageId.keycloakId(model, data.get("id"));
         this.username = data.get("username");
-        Map<String, List<String>> attributes = this.getAttributes();
-        for (Entry<String, String> e : data.entrySet()) {
-            Set<String>  newValues = new HashSet<>();
-            List<String> attribute = attributes.get(e.getKey());
-            if (attribute != null) {
-                newValues.addAll(attribute);
-            }
-            newValues.add(StringUtils.trimToNull(e.getValue()));
-            this.setAttribute(e.getKey(), newValues.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+        try {
+          Map<String, List<String>> attributes = this.getAttributes();
+          for (Entry<String, String> e : data.entrySet()) {
+              Set<String>  newValues = new HashSet<>();
+              List<String> attribute = attributes.get(e.getKey());
+              if (attribute != null) {
+                  newValues.addAll(attribute);
+              }
+              newValues.add(StringUtils.trimToNull(e.getValue()));
+              this.setAttribute(e.getKey(), newValues.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+          }
+        } catch(Exception e) {
+          log.errorv(e, "UserAdapter constructor, username={0}", this.username);
         }
     }
 


### PR DESCRIPTION
We can still authenticate the user if we have at least the username in his record.  If there is an error filling the extra fields, we want to keep going, but log the error so the admin can do something about this user's extra fields.