### PR TITLE
Allow to remove Keycloak User (not the linked RDBMS database record) with a new setting

### DIFF
--- a/src/main/java/org/opensingular/dbuserprovider/DBUserStorageProvider.java
+++ b/src/main/java/org/opensingular/dbuserprovider/DBUserStorageProvider.java
@@ -16,6 +16,7 @@ import org.keycloak.storage.StorageId;
 import org.keycloak.storage.UserStorageProvider;
 import org.keycloak.storage.user.UserLookupProvider;
 import org.keycloak.storage.user.UserQueryProvider;
+import org.keycloak.storage.user.UserRegistrationProvider;
 import org.opensingular.dbuserprovider.model.QueryConfigurations;
 import org.opensingular.dbuserprovider.model.UserAdapter;
 import org.opensingular.dbuserprovider.persistence.DataSourceProvider;
@@ -29,7 +30,7 @@ import java.util.stream.Collectors;
 
 @JBossLog
 public class DBUserStorageProvider implements UserStorageProvider,
-        UserLookupProvider, UserQueryProvider, CredentialInputUpdater, CredentialInputValidator {
+        UserLookupProvider, UserQueryProvider, CredentialInputUpdater, CredentialInputValidator, UserRegistrationProvider {
 
     private final KeycloakSession session;
     private final ComponentModel  model;
@@ -216,5 +217,21 @@ public class DBUserStorageProvider implements UserStorageProvider,
         log.infov("search for group members: realm={0} attrName={1} attrValue={2}", realm.getId(), attrName, attrValue);
 
         return Collections.emptyList();
+    }
+
+
+    @Override
+    public UserModel addUser(RealmModel realm, String username) {
+        // from documentation: "If your provider has a configuration switch to turn off adding a user, returning null from this method will skip the provider and call the next one."
+        return null;
+    }
+
+
+    @Override
+    public boolean removeUser(RealmModel realm, UserModel user) {
+
+        log.infov("unlink user: realm={0} userId={1} username={2}", realm.getId(), user.getId(), user.getUsername());
+
+        return true;
     }
 }

--- a/src/main/java/org/opensingular/dbuserprovider/DBUserStorageProvider.java
+++ b/src/main/java/org/opensingular/dbuserprovider/DBUserStorageProvider.java
@@ -229,9 +229,12 @@ public class DBUserStorageProvider implements UserStorageProvider,
 
     @Override
     public boolean removeUser(RealmModel realm, UserModel user) {
+        boolean userRemoved = repository.removeUser();
 
-        log.infov("unlink user: realm={0} userId={1} username={2}", realm.getId(), user.getId(), user.getUsername());
+        if (userRemoved) {
+          log.infov("deleted keycloak user: realm={0} userId={1} username={2}", realm.getId(), user.getId(), user.getUsername());
+        }
 
-        return true;
+        return userRemoved;
     }
 }

--- a/src/main/java/org/opensingular/dbuserprovider/DBUserStorageProviderFactory.java
+++ b/src/main/java/org/opensingular/dbuserprovider/DBUserStorageProviderFactory.java
@@ -59,7 +59,8 @@ public class DBUserStorageProviderFactory implements UserStorageProviderFactory<
                 config.get("findBySearchTerm"),
                 config.get("findPasswordHash"),
                 config.get("hashFunction"),
-                rdbms
+                rdbms,
+                config.get("allowKeycloakDelete", false)
         );
         configured = true;
     }
@@ -110,6 +111,13 @@ public class DBUserStorageProviderFactory implements UserStorageProviderFactory<
                 .type(ProviderConfigProperty.LIST_TYPE)
                 .options(RDBMS.getAllDescriptions())
                 .defaultValue(RDBMS.SQL_SERVER.getDesc())
+                .add()
+                .property()
+                .name("allowKeycloakDelete")
+                .label("Allow Keycloak's User Delete")
+                .helpText("By default, clicking Delete on a user in Keycloak is not allowed.  Activate this option to allow to Delete Keycloak's version of the user (does not touch the user record in the linked RDBMS), e.g. to clear synching issues and allow the user to be synced from scratch from the RDBMS on next use, in Production or for testing.")
+                .type(ProviderConfigProperty.BOOLEAN_TYPE)
+                .defaultValue("false")
                 .add()
 
                 //QUERIES

--- a/src/main/java/org/opensingular/dbuserprovider/model/QueryConfigurations.java
+++ b/src/main/java/org/opensingular/dbuserprovider/model/QueryConfigurations.java
@@ -12,8 +12,9 @@ public class QueryConfigurations {
     private String findPasswordHash;
     private String hashFunction;
     private RDBMS  RDBMS;
+    private boolean allowKeycloakDelete;
 
-    public QueryConfigurations(String count, String listAll, String findById, String findByUsername, String findBySearchTerm, String findPasswordHash, String hashFunction, RDBMS RDBMS) {
+    public QueryConfigurations(String count, String listAll, String findById, String findByUsername, String findBySearchTerm, String findPasswordHash, String hashFunction, RDBMS RDBMS, boolean allowKeycloakDelete) {
         this.count = count;
         this.listAll = listAll;
         this.findById = findById;
@@ -22,6 +23,7 @@ public class QueryConfigurations {
         this.findPasswordHash = findPasswordHash;
         this.hashFunction = hashFunction;
         this.RDBMS = RDBMS;
+        this.allowKeycloakDelete = allowKeycloakDelete;
     }
 
     public RDBMS getRDBMS() {
@@ -58,5 +60,9 @@ public class QueryConfigurations {
 
     public boolean isBlowfish() {
         return hashFunction.toLowerCase().contains("blowfish");
+    }
+
+    public boolean getAllowKeycloakDelete() {
+        return allowKeycloakDelete;
     }
 }

--- a/src/main/java/org/opensingular/dbuserprovider/persistence/UserRepository.java
+++ b/src/main/java/org/opensingular/dbuserprovider/persistence/UserRepository.java
@@ -161,4 +161,8 @@ public class UserRepository {
     public List<Map<String, String>> findUsersPaged(Map<String, String> params, int firstResult, int maxResults) {
         return doQuery(queryConfigurations.getListAll(), new Pageable(firstResult, maxResults), this::readMap);
     }
+
+    public boolean removeUser() {
+      return queryConfigurations.getAllowKeycloakDelete();
+  }
 }


### PR DESCRIPTION
The new setting looks like this and is OFF by default:
![image](https://user-images.githubusercontent.com/98414745/161632844-3f89356a-9f24-44a0-acdb-9b757272f403.png)

Before this PR (and still the case if the parameter stays OFF), if you try to click "Delete" on a Keycloak User fetched by the plugin, you get the error "Error! User couldn't be deleted":
![image](https://user-images.githubusercontent.com/98414745/161632958-115de8a1-b8b2-4f8b-9846-17c24b0b6cf9.png)

The PR adds the possibility, when the new setting is ON, to let Keycloak delete **its** version of the user (not the user record in the linked RDBMS), allowing the user to be re-fetched from scratch from the RDBMS on the next sync.
This is useful for testing, but also to solve sync issues for given users.

Note that the `addUser` method is implemented to satisfy the `UserRegistrationProvider` interface, but does nothing more than before: it just lets the call pass through, as per the recommendation in the Keycloak documentation here: https://www.keycloak.org/docs/latest/server_development/#:~:text=The%20addUser()%20method%20will%20be%20called