### PR TITLE
fix DB connections leak

### DIFF
--- a/src/main/java/org/opensingular/dbuserprovider/DBUserStorageProviderFactory.java
+++ b/src/main/java/org/opensingular/dbuserprovider/DBUserStorageProviderFactory.java
@@ -38,6 +38,11 @@ public class DBUserStorageProviderFactory implements UserStorageProviderFactory<
     }
 
     @Override
+    public void close() {
+      dataSourceProvider.close();
+    }
+
+    @Override
     public DBUserStorageProvider create(KeycloakSession session, ComponentModel model) {
         if (!configured) {
             configure(model);

--- a/src/main/java/org/opensingular/dbuserprovider/persistence/DataSourceProvider.java
+++ b/src/main/java/org/opensingular/dbuserprovider/persistence/DataSourceProvider.java
@@ -60,6 +60,8 @@ public class DataSourceProvider implements Closeable {
     @Override
     public void close() {
         executor.shutdownNow();
-        hikariDataSource.close();
+        if (hikariDataSource != null) {
+          hikariDataSource.close();
+        }
     }
 }


### PR DESCRIPTION
Every time the plugin is re-deployed, it is leaking the previous DB connections, up to the point where it depletes the available DB connections (especially in a Development mode with a limited number of DB Connections available, but the same would be true for Production), and the DB log would show something like this:
![image](https://user-images.githubusercontent.com/98414745/161794484-38564fe5-63db-4a92-b0d3-f324e33f1576.png)

And Keycloak would show the error "We are sorry... An internal server error has occurred":
![image](https://user-images.githubusercontent.com/98414745/161794761-cf4ce7fa-74de-4635-8de6-71b0c85d24af.png)

e.g. Checking the number of connections on a Postgresql DB, running `SELECT sum(numbackends) FROM pg_stat_database;` would show that 10 connections are leaked on each re-deploy.