### PR TITLE
New parameter to allow query attributes to always overwrite Keycloak

### DIFF
--- a/src/main/java/org/opensingular/dbuserprovider/DBUserStorageProviderFactory.java
+++ b/src/main/java/org/opensingular/dbuserprovider/DBUserStorageProviderFactory.java
@@ -65,7 +65,8 @@ public class DBUserStorageProviderFactory implements UserStorageProviderFactory<
                 config.get("findPasswordHash"),
                 config.get("hashFunction"),
                 rdbms,
-                config.get("allowKeycloakDelete", false)
+                config.get("allowKeycloakDelete", false),
+                config.get("allowDatabaseToOverwriteKeycloak", false)
         );
         configured = true;
     }
@@ -121,6 +122,14 @@ public class DBUserStorageProviderFactory implements UserStorageProviderFactory<
                 .name("allowKeycloakDelete")
                 .label("Allow Keycloak's User Delete")
                 .helpText("By default, clicking Delete on a user in Keycloak is not allowed.  Activate this option to allow to Delete Keycloak's version of the user (does not touch the user record in the linked RDBMS), e.g. to clear synching issues and allow the user to be synced from scratch from the RDBMS on next use, in Production or for testing.")
+                .type(ProviderConfigProperty.BOOLEAN_TYPE)
+                .defaultValue("false")
+                .add()
+                .property()
+                .name("allowDatabaseToOverwriteKeycloak")
+                .label("Allow DB Attributes to Overwrite Keycloak")
+                // Technically details for the following comment: we aggregate both the existing Keycloak version and the DB version of an attribute in a Set, but since e.g. email is not a list of values on the Keycloak User, the new email is never set on it.
+                .helpText("By default, once a user is loaded in Keycloak, its attributes (e.g. 'email') stay as they are in Keycloak even if an attribute of the same name now returns a different value through the query.  Activate this option to have all attributes set in the SQL query to always overwrite the existing user attributes in Keycloak (e.g. if Keycloak user has email 'test@test.com' but the query fetches a field named 'email' that has a value 'example@exemple.com', the Keycloak user will now have email attribute = 'example@exemple.com').")
                 .type(ProviderConfigProperty.BOOLEAN_TYPE)
                 .defaultValue("false")
                 .add()

--- a/src/main/java/org/opensingular/dbuserprovider/model/QueryConfigurations.java
+++ b/src/main/java/org/opensingular/dbuserprovider/model/QueryConfigurations.java
@@ -13,8 +13,9 @@ public class QueryConfigurations {
     private String hashFunction;
     private RDBMS  RDBMS;
     private boolean allowKeycloakDelete;
+    private boolean allowDatabaseToOverwriteKeycloak;
 
-    public QueryConfigurations(String count, String listAll, String findById, String findByUsername, String findBySearchTerm, String findPasswordHash, String hashFunction, RDBMS RDBMS, boolean allowKeycloakDelete) {
+    public QueryConfigurations(String count, String listAll, String findById, String findByUsername, String findBySearchTerm, String findPasswordHash, String hashFunction, RDBMS RDBMS, boolean allowKeycloakDelete, boolean allowDatabaseToOverwriteKeycloak) {
         this.count = count;
         this.listAll = listAll;
         this.findById = findById;
@@ -24,6 +25,7 @@ public class QueryConfigurations {
         this.hashFunction = hashFunction;
         this.RDBMS = RDBMS;
         this.allowKeycloakDelete = allowKeycloakDelete;
+        this.allowDatabaseToOverwriteKeycloak = allowDatabaseToOverwriteKeycloak;
     }
 
     public RDBMS getRDBMS() {
@@ -64,5 +66,9 @@ public class QueryConfigurations {
 
     public boolean getAllowKeycloakDelete() {
         return allowKeycloakDelete;
+    }
+
+    public boolean getAllowDatabaseToOverwriteKeycloak() {
+        return allowDatabaseToOverwriteKeycloak;
     }
 }

--- a/src/main/java/org/opensingular/dbuserprovider/model/UserAdapter.java
+++ b/src/main/java/org/opensingular/dbuserprovider/model/UserAdapter.java
@@ -22,7 +22,7 @@ public class UserAdapter extends AbstractUserAdapterFederatedStorage {
     private final String keycloakId;
     private       String username;
 
-    public UserAdapter(KeycloakSession session, RealmModel realm, ComponentModel model, Map<String, String> data) {
+    public UserAdapter(KeycloakSession session, RealmModel realm, ComponentModel model, Map<String, String> data, boolean allowDatabaseToOverwriteKeycloak) {
         super(session, realm, model);
         this.keycloakId = StorageId.keycloakId(model, data.get("id"));
         this.username = data.get("username");
@@ -30,9 +30,11 @@ public class UserAdapter extends AbstractUserAdapterFederatedStorage {
           Map<String, List<String>> attributes = this.getAttributes();
           for (Entry<String, String> e : data.entrySet()) {
               Set<String>  newValues = new HashSet<>();
-              List<String> attribute = attributes.get(e.getKey());
-              if (attribute != null) {
-                  newValues.addAll(attribute);
+              if (!allowDatabaseToOverwriteKeycloak) {
+                List<String> attribute = attributes.get(e.getKey());
+                if (attribute != null) {
+                    newValues.addAll(attribute);
+                }
               }
               newValues.add(StringUtils.trimToNull(e.getValue()));
               this.setAttribute(e.getKey(), newValues.stream().filter(Objects::nonNull).collect(Collectors.toList()));


### PR DESCRIPTION
Adds the following parameter that is OFF by default to keep the current behaviour. 
![image](https://user-images.githubusercontent.com/98414745/164800619-977ff548-53d2-42d5-b3de-139404027d16.png)

By default, once a user is loaded in Keycloak, its attributes (e.g. 'email') stay as they are in Keycloak even if an attribute of the same name now returns a different value through the query. (Technically public UserAdapter aggregates both the existing Keycloak version and the DB version of an attribute in a Set<String>, but since e.g. email is not a **list** of values on the Keycloak User, the new email - 2nd in the Set - is never assigned to the user. - not sure this is a good default behaviour, I guess it should either be the value from the DB or the value from Keycloak, but not a set of both, but I didn't touch the default behaviour, I let it as is)

This new option allows to have all the attributes that are set in the SQL query to always overwrite the existing user attributes in Keycloak (e.g. if Keycloak user has email 'test@test.com' but the query fetches a field named 'email' that has a value 'example@exemple.com', the Keycloak user will now have email attribute = 'example@exemple.com' instead of keeping 'test@test.com').