### PR TITLE
Switch bcrypt lib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,9 +104,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.mindrot</groupId>
-            <artifactId>jbcrypt</artifactId>
-            <version>0.4</version>
+            <groupId>at.favre.lib</groupId>
+            <artifactId>bcrypt</artifactId>
+            <version>0.9.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/org/opensingular/dbuserprovider/persistence/UserRepository.java
+++ b/src/main/java/org/opensingular/dbuserprovider/persistence/UserRepository.java
@@ -5,7 +5,7 @@ import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.codec.binary.StringUtils;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.NotImplementedException;
-import org.mindrot.jbcrypt.BCrypt;
+import at.favre.lib.crypto.bcrypt.BCrypt;
 import org.opensingular.dbuserprovider.DBUserStorageException;
 import org.opensingular.dbuserprovider.model.QueryConfigurations;
 import org.opensingular.dbuserprovider.util.PBKDF2SHA256HashingUtil;
@@ -144,7 +144,7 @@ public class UserRepository {
     public boolean validateCredentials(String username, String password) {
         String hash = Optional.ofNullable(doQuery(queryConfigurations.getFindPasswordHash(), null, this::readString, username)).orElse("");
         if (queryConfigurations.isBlowfish()) {
-            return !hash.isEmpty() && BCrypt.checkpw(password, hash);
+            return !hash.isEmpty() && BCrypt.verifyer().verify(password.toCharArray(), hash).verified;
         } else {
             String hashFunction = queryConfigurations.getHashFunction();
 


### PR DESCRIPTION
jBCrypt hasn't been updated since 2015 and supports only `$2a$` version.
It can't validate passwords hashed with `$2y$` version (ex: generated through PHP).

I switched to [another lib](https://github.com/patrickfav/bcrypt) that is more recent, maintained and under Apache 2.0 license.