### PR TITLE
Prevent federated attribute deadlocks

### DIFF
--- a/src/main/java/org/opensingular/dbuserprovider/model/UserAdapter.java
+++ b/src/main/java/org/opensingular/dbuserprovider/model/UserAdapter.java
@@ -8,10 +8,14 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.storage.StorageId;
 import org.keycloak.storage.adapter.AbstractUserAdapterFederatedStorage;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -27,21 +31,41 @@ public class UserAdapter extends AbstractUserAdapterFederatedStorage {
         this.keycloakId = StorageId.keycloakId(model, data.get("id"));
         this.username = data.get("username");
         try {
-          Map<String, List<String>> attributes = this.getAttributes();
-          for (Entry<String, String> e : data.entrySet()) {
-              Set<String>  newValues = new HashSet<>();
-              if (!allowDatabaseToOverwriteKeycloak) {
-                List<String> attribute = attributes.get(e.getKey());
-                if (attribute != null) {
-                    newValues.addAll(attribute);
-                }
-              }
-              newValues.add(StringUtils.trimToNull(e.getValue()));
-              this.setAttribute(e.getKey(), newValues.stream().filter(Objects::nonNull).collect(Collectors.toList()));
-          }
+          Map<String, List<String>> currentAttributes = new HashMap<>(super.getAttributes());
+          data.entrySet().stream()
+              .sorted(Comparator.comparing(Entry::getKey))
+              .forEach(e -> synchronizeAttribute(currentAttributes, e, allowDatabaseToOverwriteKeycloak));
         } catch(Exception e) {
           log.errorv(e, "UserAdapter constructor, username={0}", this.username);
         }
+    }
+
+    private void synchronizeAttribute(Map<String, List<String>> currentAttributes, Entry<String, String> entry, boolean allowDatabaseToOverwriteKeycloak) {
+        List<String> existingValues = normalizeValues(currentAttributes.get(entry.getKey()));
+        List<String> newValues = mergeValues(existingValues, entry.getValue(), allowDatabaseToOverwriteKeycloak);
+        if (!existingValues.equals(newValues)) {
+            this.setAttribute(entry.getKey(), newValues);
+            currentAttributes.put(entry.getKey(), newValues);
+        }
+    }
+
+    private List<String> mergeValues(List<String> existingValues, String databaseValue, boolean allowDatabaseToOverwriteKeycloak) {
+        Set<String> mergedValues = new LinkedHashSet<>();
+        if (!allowDatabaseToOverwriteKeycloak) {
+            mergedValues.addAll(existingValues);
+        }
+        String normalizedDatabaseValue = StringUtils.trimToNull(databaseValue);
+        if (normalizedDatabaseValue != null) {
+            mergedValues.add(normalizedDatabaseValue);
+        }
+        return new ArrayList<>(mergedValues);
+    }
+
+    private List<String> normalizeValues(List<String> values) {
+        if (values == null || values.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return values.stream().filter(Objects::nonNull).collect(Collectors.toList());
     }
 
 

--- a/src/main/java/org/opensingular/dbuserprovider/persistence/UserRepository.java
+++ b/src/main/java/org/opensingular/dbuserprovider/persistence/UserRepository.java
@@ -64,13 +64,13 @@ public class UserRepository {
     private List<Map<String, String>> readMap(ResultSet rs) {
         try {
             List<Map<String, String>> data         = new ArrayList<>();
-            Set<String>               columnsFound = new HashSet<>();
+            Set<String>               columnsFound = new LinkedHashSet<>();
             for (int i = 1; i <= rs.getMetaData().getColumnCount(); i++) {
                 String columnLabel = rs.getMetaData().getColumnLabel(i);
                 columnsFound.add(columnLabel);
             }
             while (rs.next()) {
-                Map<String, String> result = new HashMap<>();
+                Map<String, String> result = new LinkedHashMap<>();
                 for (String col : columnsFound) {
                     result.put(col, rs.getString(col));
                 }


### PR DESCRIPTION
## Summary
- make federated attribute synchronization deterministic by sorting attribute keys
- avoid rewriting attributes when values are unchanged
- preserve result-set column order to avoid unstable attribute update ordering

## Problem
Concurrent user loads were triggering repeated writes to Keycloak federated storage, causing overlapping deletes against  in PostgreSQL and produciConcurdlConcurrent user loads were triggering repeated writes to Keycloak federated packagConcurrent user loads were triggering repeated writes celled before completion